### PR TITLE
Changing default configs

### DIFF
--- a/configs/e2e.conf
+++ b/configs/e2e.conf
@@ -1,6 +1,8 @@
 ###### Object detection config ######
 --obstacle_detection
 --nosimulator_obstacle_detection
+--obstacle_detection_model_paths=dependencies/models/obstacle_detection/faster-rcnn/
+--obstacle_detection_model_names=faster-rcnn
 --obstacle_detection_gpu_memory_fraction=0.2
 --obstacle_detection_min_score_threshold=0.3
 #--evaluate_obstacle_detection
@@ -35,7 +37,7 @@
 --simulator_num_vehicles=0
 --camera_image_width=1280
 --camera_image_height=720
---simulator_town=7
+--simulator_town=1
 ######### Logging config #########
 --log_file_name=pylot.log
 --csv_log_file_name=pylot.csv


### PR DESCRIPTION
### Summary of Changes
* Added flags for setting the object detection model & path in preparation for switching the model
* Changed the default simulator town to 1 since the official pylot Docker container does not currently have town 7 included. Town 7 is a part of the additional maps package which needs to be imported separately.