### PR TITLE
Added support to use model output dictionary keys from file

### DIFF
--- a/configs/e2e.conf
+++ b/configs/e2e.conf
@@ -3,6 +3,8 @@
 --nosimulator_obstacle_detection
 --obstacle_detection_model_paths=dependencies/models/obstacle_detection/faster-rcnn/
 --obstacle_detection_model_names=faster-rcnn
+--path_coco_labels=dependencies/models/pylot.names
+--path_model_outputs=dependencies/models/pylot.outputs
 --obstacle_detection_gpu_memory_fraction=0.2
 --obstacle_detection_min_score_threshold=0.3
 #--evaluate_obstacle_detection

--- a/dependencies/models/custom.outputs
+++ b/dependencies/models/custom.outputs
@@ -1,0 +1,4 @@
+detection_boxes
+detection_scores
+detection_classes
+num_detections

--- a/dependencies/models/pylot.outputs
+++ b/dependencies/models/pylot.outputs
@@ -1,0 +1,4 @@
+boxes
+scores
+classes
+detections

--- a/pylot/perception/detection/detection_operator.py
+++ b/pylot/perception/detection/detection_operator.py
@@ -9,7 +9,7 @@ import numpy as np
 import pylot.utils
 from pylot.perception.detection.obstacle import Obstacle
 from pylot.perception.detection.utils import BoundingBox2D, \
-    OBSTACLE_LABELS, load_coco_bbox_colors, load_coco_labels
+    OBSTACLE_LABELS, load_coco_bbox_colors, load_coco_labels, load_model_outputs
 from pylot.perception.messages import ObstaclesMessage
 
 import tensorflow as tf
@@ -74,6 +74,7 @@ class DetectionOperator(erdos.Operator):
         logger.debug('\n\n*********Path of the model using now: %s', model_path)
 
         self._coco_labels = load_coco_labels(self._flags.path_coco_labels)
+        self._model_outputs = load_model_outputs(self._flags.path_model_outputs)
         self._bbox_colors = load_coco_bbox_colors(self._coco_labels)
         # Unique bounding box id. Incremented for each bounding box.
         self._unique_id = 0
@@ -206,10 +207,10 @@ class DetectionOperator(erdos.Operator):
         infer = self._model.signatures['serving_default']
         result = infer(tf.convert_to_tensor(value=image_np_expanded))
 
-        boxes = result['boxes']
-        scores = result['scores']
-        classes = result['classes']
-        num_detections = result['detections']
+        boxes = result[self._model_outputs['boxes']]
+        scores = result[self._model_outputs['scores']]
+        classes = result[self._model_outputs['classes']]
+        num_detections = result[self._model_outputs['detections']]
 
         num_detections = int(num_detections[0])
         res_classes = [int(cls) for cls in classes[0][:num_detections]]

--- a/pylot/perception/detection/utils.py
+++ b/pylot/perception/detection/utils.py
@@ -404,6 +404,20 @@ def load_coco_labels(labels_path):
             index += 1
     return labels_map
 
+def load_model_outputs(outputs_path):
+    """Returns a map from the model output to the dictionary key.
+
+    Args:
+        outputs_path (:obj:`str`): Path to a file storing a dictionary key on each line.
+    """
+    outputs_map = {}
+    with open(outputs_path) as outputs_file:
+        outputs = outputs_file.read().splitlines()
+        outputs_map['boxes'] = outputs[0]
+        outputs_map['scores'] = outputs[1]
+        outputs_map['classes'] = outputs[2]
+        outputs_map['detections'] = outputs[3]
+    return outputs_map
 
 def load_coco_bbox_colors(coco_labels):
     """Returns a map from label to color."""

--- a/pylot/perception/flags.py
+++ b/pylot/perception/flags.py
@@ -16,6 +16,8 @@ flags.DEFINE_float('obstacle_detection_min_score_threshold', 0.5,
                    'Min score threshold for bounding box')
 flags.DEFINE_string('path_coco_labels', 'dependencies/models/pylot.names',
                     'Path to the COCO labels')
+flags.DEFINE_string('path_model_outputs', 'dependencies/models/pylot.outputs',
+                    'Path to model output dictionary keys')
 flags.DEFINE_float('dynamic_obstacle_distance_threshold', 50.0,
                    'Max distance to consider dynamic obstacles [m]')
 flags.DEFINE_float(


### PR DESCRIPTION
### Background

Pylot currently assumes that the output from the pretrained TF models is a dictionary that contains the following keys: `boxes`, `scores`, `classes`,  and `detections`.

However, if we use a different model from the TF object detection zoo, the keys in the output dictionary is slightly different: `detection_boxes`, `detection_scores`, `detection_classes`, and `num_detections`.

Instead of modifying the `detection_operator` implementation to use the correct keys depending on the model we're using, we instead add a flag for the path of a file that specifies these keys.

### Summary of Changes
* Added a new flag called `path_model_outputs`. This points to a file that specifies the Python dictionary keys that Pylot should use to obtain the detection model outputs such as the bounding boxes, detection scores, class IDs of objects detected, and the number of detections.
* Added new files for the dictionary keys:
    * `pylot.outputs` are the defaults
    * `custom.outputs` can be defined by us depending on the detection model we are using.

### Validation
* Was able to successfully enable object detection using the [SSD ResNet50 V1 FPN 640x640 (RetinaNet50)](http://download.tensorflow.org/models/object_detection/tf2/20200711/ssd_resnet50_v1_fpn_640x640_coco17_tpu-8.tar.gz) model from the TF model zoo with the following `e2e.conf` flags:

```
--obstacle_detection_model_names=ssd_resnet50
--obstacle_detection_model_paths=dependencies/models/obstacle_detection/ssd_resnet50/
--path_coco_labels=dependencies/models/coco.names
--path_model_outputs=dependencies/models/custom.outputs
```
![image](https://github.com/aozo/pylot/assets/5497787/b96a7ad5-9006-4951-8420-5772be97c46d)
