### PR TITLE
Enable detection of vehicles and pedestrians

### DIFF
--- a/configs/experimental/yolo_town1_obstacles.conf
+++ b/configs/experimental/yolo_town1_obstacles.conf
@@ -1,0 +1,57 @@
+###### Object detection config ######
+--obstacle_detection
+--nosimulator_obstacle_detection
+# --obstacle_detection_model_paths=dependencies/models/obstacle_detection/faster-rcnn/
+# --obstacle_detection_model_names=faster-rcnn
+# --path_coco_labels=dependencies/models/pylot.names
+# --path_model_outputs=dependencies/models/pylot.outputs
+--obstacle_detection_model_paths=dependencies/models/obstacle_detection/yolo/
+--obstacle_detection_model_names=yolo
+--path_coco_labels=dependencies/models/carla_obstacles.names
+--path_model_outputs=dependencies/models/custom.outputs
+--path_yolo_anchors=dependencies/models/yolo3_anchors.txt
+--obstacle_detection_gpu_memory_fraction=0.2
+--obstacle_detection_min_score_threshold=0.5
+#--evaluate_obstacle_detection
+###### Depth #####
+--perfect_depth_estimation
+###### Segmentation config ######
+--perfect_segmentation
+###### Prediction config ######
+--obstacle_tracking
+--tracking_num_steps=10
+--prediction
+--prediction_type=linear
+--prediction_num_past_steps=10
+--prediction_num_future_steps=10
+###### Planning config #####
+--planning_type=waypoint
+###### Control config #####
+--control=mpc
+#--lane_detection
+#--perfect_lane_detection
+--stop_for_vehicles=True
+--stop_for_people=True
+--stop_for_traffic_lights=False
+#--target_speed=40
+###### Carla config ######
+# This seed spawns the ego car behind two vehicles which eventually stops at a red light.
+--random_seed=618549084
+--simulator_num_people=80
+--simulator_num_vehicles=80
+--camera_image_width=1280
+--camera_image_height=720
+--simulator_town=1
+######### Logging config #########
+--log_file_name=pylot.log
+--csv_log_file_name=pylot.csv
+--v=1
+######### Other config #########
+--visualize_detected_obstacles
+--visualize_detected_traffic_lights
+--visualize_segmentation
+--visualize_prediction
+--visualize_waypoints
+#--draw_waypoints_on_world=True
+#--draw_waypoints_on_camera_frames
+--data_path=data/

--- a/dependencies/models/carla_obstacles.names
+++ b/dependencies/models/carla_obstacles.names
@@ -1,0 +1,7 @@
+bike
+motobike
+person
+speed limit 30
+speed limit 60
+speed limit 90
+vehicle

--- a/pylot/perception/detection/detection_operator.py
+++ b/pylot/perception/detection/detection_operator.py
@@ -255,7 +255,8 @@ class DetectionOperator(erdos.Operator):
         anchors = [float(x) for x in anchors.split(',')]
         anchors = np.array(anchors).reshape(-1, 2)
 
-        boxes, classes, scores = yolo3_postprocess_np(prediction, image_shape, anchors, 3, model_input_shape, elim_grid_sense=False)
+        num_classes = len(self._coco_labels)
+        boxes, classes, scores = yolo3_postprocess_np(prediction, image_shape, anchors, num_classes, model_input_shape, elim_grid_sense=False)
 
         # Normalize bounding box to range [0, 1]
         norm_boxes = []

--- a/pylot/perception/detection/obstacle.py
+++ b/pylot/perception/detection/obstacle.py
@@ -4,7 +4,7 @@ import pylot.utils
 from pylot.perception.detection.utils import BoundingBox2D, BoundingBox3D, \
     get_bounding_box_in_camera_view
 
-VEHICLE_LABELS = {'car', 'bicycle', 'motorcycle', 'bus', 'truck', 'vehicle'}
+VEHICLE_LABELS = {'car', 'bicycle', 'bike', 'motobike', 'motorcycle', 'bus', 'truck', 'vehicle'}
 
 
 class Obstacle(object):

--- a/pylot/perception/detection/utils.py
+++ b/pylot/perception/detection/utils.py
@@ -5,7 +5,7 @@ import numpy as np
 import pylot.utils
 
 OBSTACLE_LABELS = {
-    'car', 'bicycle', 'motorcycle', 'bus', 'truck', 'vehicle', 'person',
+    'car', 'bicycle', 'bike', 'motobike', 'motorcycle', 'bus', 'truck', 'vehicle', 'person',
     'stop sign', 'parking meter', 'cat', 'dog', 'speed limit 30',
     'speed limit 60', 'speed limit 90'
 }
@@ -15,6 +15,8 @@ PYLOT_BBOX_COLOR_MAP = {
     'vehicle': [128, 0, 0],
     'car': [128, 0, 0],
     'bicycle': [128, 0, 0],
+    'bike': [128, 0, 0],
+    'motobike': [128, 0, 0],
     'motorcycle': [128, 0, 0],
     'bus': [128, 0, 0],
     'truck': [128, 0, 0],

--- a/pylot/planning/world.py
+++ b/pylot/planning/world.py
@@ -275,6 +275,7 @@ class World(object):
         for obstacle in self.obstacle_predictions:
             if obstacle.is_person() and self._flags.stop_for_people:
                 new_speed_factor_p = self.stop_person(obstacle, wp_vector)
+                print("[DEBUG] Person: Speed Factor: " + str(new_speed_factor_p))
                 if new_speed_factor_p < speed_factor_p:
                     speed_factor_p = new_speed_factor_p
                     self._logger.debug(
@@ -282,6 +283,7 @@ class World(object):
                             timestamp, obstacle.id, speed_factor_p))
             elif obstacle.is_vehicle() and self._flags.stop_for_vehicles:
                 new_speed_factor_v = self.stop_vehicle(obstacle, wp_vector)
+                print("[DEBUG] Vehicle: Speed Factor: " + str(new_speed_factor_v))
                 if new_speed_factor_v < speed_factor_v:
                     speed_factor_v = new_speed_factor_v
                     self._logger.debug(
@@ -298,12 +300,12 @@ class World(object):
                 valid_tl, new_speed_factor_tl = self.stop_traffic_light(
                     obstacle, wp_vector, wp_angle)
                 semaphorized_junction = semaphorized_junction or valid_tl
+                print("[DEBUG] Traffic Light: Speed Factor: " + str(new_speed_factor_tl))
                 if new_speed_factor_tl < speed_factor_tl:
                     speed_factor_tl = new_speed_factor_tl
                     self._logger.debug(
                         '@{}: traffic light {} reduced speed factor to {}'.
                         format(timestamp, obstacle.id, speed_factor_tl))
-                print("[DEBUG] Current Speed Factor: " + str(speed_factor_tl) + " New Speed Factor: " + str(new_speed_factor_tl))
 
         if self._flags.stop_at_uncontrolled_junctions:
             if (self._map is not None and not semaphorized_junction

--- a/pylot/simulation/carla_operator.py
+++ b/pylot/simulation/carla_operator.py
@@ -45,7 +45,10 @@ class CarlaOperator(erdos.Operator):
             vehicle_id_stream: WriteStream, open_drive_stream: WriteStream,
             global_trajectory_stream: WriteStream, flags):
         if flags.random_seed:
-            random.seed(flags.random_seed)
+            seed = flags.random_seed
+        else:
+            seed = random.randint(0, 1000000000)
+        random.seed(seed)
         # Register callback on control stream.
         control_stream.add_callback(self.on_control_msg)
         erdos.add_watermark_callback([release_sensor_stream], [],
@@ -66,6 +69,7 @@ class CarlaOperator(erdos.Operator):
         self._flags = flags
         self._logger = erdos.utils.setup_logging(self.config.name,
                                                  self.config.log_file_name)
+        self._logger.debug('Random seed: {}'.format(seed))
         self._csv_logger = erdos.utils.setup_csv_logging(
             self.config.name + '-csv', self.config.csv_log_file_name)
         # Connect to simulator and retrieve the world running.

--- a/scripts/split_dataset.py
+++ b/scripts/split_dataset.py
@@ -24,9 +24,20 @@ LIGHT_CLASSES = [
         "traffic_light_orange",
         "traffic_light_red"]
 
+OBSTACLE_CLASSES = [
+        "bike",
+        "motobike",
+        "person",
+        "traffic_sign_30",
+        "traffic_sign_60",
+        "traffic_sign_90",
+        "vehicle"]
+
 if __name__ == "__main__":
 
     parser = argparse.ArgumentParser(description = "Splits data set into multiple data sets according to categories.")
+    parser.add_argument("--split", "-s", action="store_true")
+    parser.add_argument("--view", "-v", action="store_true")
     parser.add_argument("--data", "-d")
     parser.add_argument("--labels", "-l")
     args = parser.parse_args()
@@ -36,48 +47,82 @@ if __name__ == "__main__":
     (label_file_name, _) = os.path.splitext(args.labels)
     dataset_type = fo.types.COCODetectionDataset
 
-    signs_dataset = fo.Dataset.from_dir( \
-            dataset_type=dataset_type, \
-            data_path=data_path, \
-            labels_path=labels_path, \
-            classes=SIGN_CLASSES, \
-            name="signs_dataset")
-
-    lights_dataset = fo.Dataset.from_dir( \
-            dataset_type=dataset_type, \
-            data_path=data_path, \
-            labels_path=labels_path, \
-            classes=LIGHT_CLASSES, \
-            name="lights_dataset")
-
-    if signs_dataset.stats()["samples_count"] > 0:
-        signs_dataset.export(
-                labels_path=label_file_name + "_signs.json", \
+    if args.split:
+        signs_dataset = fo.Dataset.from_dir( \
                 dataset_type=dataset_type, \
-                classes=["RSVD"] + SIGN_CLASSES) # Class ID 0 is reserved for COCO datasets
+                data_path=data_path, \
+                labels_path=labels_path, \
+                classes=SIGN_CLASSES, \
+                name="signs_dataset")
 
-        # Reformat JSON with line breaks and indentation
-        with open(label_file_name + "_signs.json", "r+") as f:
-            data = json.load(f)
-            j = json.dumps(data, indent=4)
-            f.seek(0)
-            f.write(j)
-            f.truncate()
-
-        print("Num sign annotations: " + str(len(data["annotations"])))
-
-    if lights_dataset.stats()["samples_count"] > 0:
-        lights_dataset.export(
-                labels_path=label_file_name + "_lights.json", \
+        lights_dataset = fo.Dataset.from_dir( \
                 dataset_type=dataset_type, \
-                classes=["RSVD"] + LIGHT_CLASSES) # Class ID 0 is reserved for COCO datasets
+                data_path=data_path, \
+                labels_path=labels_path, \
+                classes=LIGHT_CLASSES, \
+                name="lights_dataset")
 
-        # Reformat JSON with line breaks and indentation
-        with open(label_file_name + "_lights.json", "r+") as f:
-            data = json.load(f)
-            j = json.dumps(data, indent=4)
-            f.seek(0)
-            f.write(j)
-            f.truncate()
+        obstacles_dataset = fo.Dataset.from_dir( \
+                dataset_type=dataset_type, \
+                data_path=data_path, \
+                labels_path=labels_path, \
+                classes=OBSTACLE_CLASSES, \
+                name="obstacles_dataset")
 
-        print("Num light annotations: " + str(len(data["annotations"])))
+        if signs_dataset.stats()["samples_count"] > 0:
+            signs_dataset.export(
+                    labels_path=label_file_name + "_signs.json", \
+                    dataset_type=dataset_type, \
+                    classes=["RSVD"] + SIGN_CLASSES) # Class ID 0 is reserved for COCO datasets
+
+            # Reformat JSON with line breaks and indentation
+            with open(label_file_name + "_signs.json", "r+") as f:
+                data = json.load(f)
+                j = json.dumps(data, indent=4)
+                f.seek(0)
+                f.write(j)
+                f.truncate()
+
+            print("Num sign annotations: " + str(len(data["annotations"])))
+
+        if lights_dataset.stats()["samples_count"] > 0:
+            lights_dataset.export(
+                    labels_path=label_file_name + "_lights.json", \
+                    dataset_type=dataset_type, \
+                    classes=["RSVD"] + LIGHT_CLASSES) # Class ID 0 is reserved for COCO datasets
+
+            # Reformat JSON with line breaks and indentation
+            with open(label_file_name + "_lights.json", "r+") as f:
+                data = json.load(f)
+                j = json.dumps(data, indent=4)
+                f.seek(0)
+                f.write(j)
+                f.truncate()
+
+            print("Num light annotations: " + str(len(data["annotations"])))
+
+        if obstacles_dataset.stats()["samples_count"] > 0:
+            obstacles_dataset.export(
+                    labels_path=label_file_name + "_obstacles.json", \
+                    dataset_type=dataset_type, \
+                    classes=["RSVD"] + OBSTACLE_CLASSES) # Class ID 0 is reserved for COCO datasets
+
+            # Reformat JSON with line breaks and indentation
+            with open(label_file_name + "_obstacles.json", "r+") as f:
+                data = json.load(f)
+                j = json.dumps(data, indent=4)
+                f.seek(0)
+                f.write(j)
+                f.truncate()
+
+            print("Num obstacle annotations: " + str(len(data["annotations"])))
+
+    if args.view:
+        dataset = fo.Dataset.from_dir( \
+                dataset_type=dataset_type, \
+                data_path=data_path, \
+                labels_path=labels_path, \
+                name="dataset")
+
+        session = fo.launch_app(dataset)
+        session.wait()


### PR DESCRIPTION
### Summary of changes
* Added config file for detecting obstacles.
* Added logs to print out the random seed that was used so that it can be saved to reproduce safety critical scenarios.
* Added a new option in the split dataset script to be able to visualize the dataset in the FiftyOne GUI which also annotates the dataset with ground truth bounding boxes.